### PR TITLE
Add FastAPI app with root endpoint

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,8 @@
+from fastapi import FastAPI
+from typing import Dict
+
+app = FastAPI()
+
+@app.get("/")
+def read_root() -> Dict[str, str]:
+    return {"message": "Hello from FastAPI backend!"}


### PR DESCRIPTION
Initialized FastAPI application in main.py with a root GET endpoint returning a welcome message. Added empty __init__.py to mark the app directory as a Python package.